### PR TITLE
Fix a syntax error in the sample code.

### DIFF
--- a/src/flow_control/match/destructuring/destructure_structures.md
+++ b/src/flow_control/match/destructuring/destructure_structures.md
@@ -32,7 +32,7 @@ fn main() {
         Foo { y, .. } => println!("y = {}, we don't care about x", y),
         // this will give an error: pattern does not mention field `x`
         // `x`に言及していないため、以下はエラーになる。
-        //Foo { y } => println!("y = {}", y);
+        //Foo { y } => println!("y = {}", y),
     }
 }
 ```


### PR DESCRIPTION
`destructure_structures.md`の中のサンプルコードに

```rust
        // `x`に言及していないため、以下はエラーになる。
        //Foo { y } => println!("y = {}", y);
```

と書かれてコメントアウトされたコードがありますが、このコードは`match`式の中にもかかわらず`;`で終わっているため、コードの本来の意図とは異なり、`x`の言及にかかわらずエラーになります。

そのため、コードの意図に添ったエラーとするために、末尾の`;`を`,`に置き換える修正をおこないました。

※原文の[こちら]( https://github.com/rust-lang/rust-by-example/pull/1336 )のプルリクと同じ修正になります。

---

In a sample code of `destructure_structures.md`, there is a code that is commented out with "// this will give an error: pattern does not mention field `x`".
But this line ends with a `;` even though it is in `match`, so it gives an error regardless of the mention of `x`.

So replace the trailing semicolon with a comma.

Note: This will be the same modification as [this pull request]( https://github.com/rust-lang/rust-by-example/pull/1336 ) in the original document.